### PR TITLE
Make node-sass pass in citgm

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -70,6 +70,7 @@ function getHumanNodeVersion(abi) {
     case 48: return 'Node.js 6.x';
     case 51: return 'Node.js 7.x';
     case 52: return 'Node.js 8.x';
+    case 56: return 'Node.js 9.x';
     default: return false;
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "node_modules/.bin/eslint bin/node-sass lib scripts test",
     "test": "node_modules/.bin/mocha test/api.js",
     "build": "node scripts/build.js --force",
-    "prepublish": "not-in-install && node scripts/prepublish.js || in-install"
+    "prepare": "not-in-install && node scripts/prepublish.js || in-install"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.3.2",
-    "node-addon-api": "^0.6.2",
+    "node-addon-api": "^1.0.0",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
     "request": "^2.61.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "node_modules/.bin/eslint bin/node-sass lib scripts test",
     "test": "node_modules/.bin/mocha test/api.js",
     "build": "node scripts/build.js --force",
-    "prepare": "not-in-install && node scripts/prepublish.js || in-install"
+    "prepare": "in-publish && node scripts/prepublish.js || not-in-publish"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.3.2",
-    "node-addon-api": "^0.5.1",
+    "node-addon-api": "^0.6.2",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
     "request": "^2.61.0",

--- a/package.json
+++ b/package.json
@@ -65,13 +65,13 @@
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.3.2",
+    "node-addon-api": "^0.5.1",
     "node-gyp": "^3.3.1",
     "npmlog": "^4.0.0",
     "request": "^2.61.0",
     "sass-graph": "^2.1.1",
     "stdout-stream": "^1.4.0",
-    "unicode-9.0.0": "^0.7.0",
-    "node-addon-api": "0.3.0"
+    "unicode-9.0.0": "^0.7.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.8",

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -44,7 +44,7 @@ int ExtractOptions(napi_env e, napi_value options, void* cptr, sass_context_wrap
   CHECK_NAPI_RESULT(napi_typeof(e, result_, &t));
 
   if (t != napi_object) {
-    CHECK_NAPI_RESULT(napi_throw_type_error(e, "\"result\" element is not an object"));
+    CHECK_NAPI_RESULT(napi_throw_type_error(e, nullptr, "\"result\" element is not an object"));
     return -1;
   }
 
@@ -268,7 +268,7 @@ void GetStats(napi_env env, sass_context_wrapper* ctx_w, Sass_Context* ctx) {
   if (t == napi_object) {
     CHECK_NAPI_RESULT(napi_set_named_property(env, propertyStats, "includedFiles", arr));
   } else {
-    CHECK_NAPI_RESULT(napi_throw_type_error(env, "\"result.stats\" element is not an object"));
+    CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "\"result.stats\" element is not an object"));
   }
 }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -334,7 +334,7 @@ void MakeCallback(uv_work_t* req) {
     assert(success_cb != nullptr);
 
     napi_value unused;
-    CHECK_NAPI_RESULT(napi_make_callback(ctx_w->env, global, success_cb, 0, nullptr, &unused));
+    CHECK_NAPI_RESULT(napi_make_callback(ctx_w->env, nullptr, global, success_cb, 0, nullptr, &unused));
   }
   else if (ctx_w->error_callback) {
     // if error, do callback(error)
@@ -352,7 +352,7 @@ void MakeCallback(uv_work_t* req) {
     assert(error_cb != nullptr);
 
     napi_value unused;
-    CHECK_NAPI_RESULT(napi_make_callback(ctx_w->env, global, error_cb, 1, argv, &unused));
+    CHECK_NAPI_RESULT(napi_make_callback(ctx_w->env, nullptr, global, error_cb, 1, argv, &unused));
   }
 
   sass_free_context_wrapper(ctx_w);
@@ -467,17 +467,17 @@ napi_value libsass_version(napi_env env, napi_callback_info info) {
   return str;
 }
 
-void Init(napi_env env, napi_value target, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value target) {
   napi_value functionRender;
-  CHECK_NAPI_RESULT(napi_create_function(env, "render", render, nullptr, &functionRender));
+  CHECK_NAPI_RESULT(napi_create_function(env, "render", -1, render, nullptr, &functionRender));
   napi_value functionRenderSync;
-  CHECK_NAPI_RESULT(napi_create_function(env, "renderSync", render_sync, nullptr, &functionRenderSync));
+  CHECK_NAPI_RESULT(napi_create_function(env, "renderSync", -1, render_sync, nullptr, &functionRenderSync));
   napi_value functionRenderFile;
-  CHECK_NAPI_RESULT(napi_create_function(env, "renderFile", render_file, nullptr, &functionRenderFile));
+  CHECK_NAPI_RESULT(napi_create_function(env, "renderFile", -1, render_file, nullptr, &functionRenderFile));
   napi_value functionRenderFileSync;
-  CHECK_NAPI_RESULT(napi_create_function(env, "renderFileSync", render_file_sync, nullptr, &functionRenderFileSync));
+  CHECK_NAPI_RESULT(napi_create_function(env, "renderFileSync", -1, render_file_sync, nullptr, &functionRenderFileSync));
   napi_value functionLibsassVersion;
-  CHECK_NAPI_RESULT(napi_create_function(env, "libsassVersion", libsass_version, nullptr, &functionLibsassVersion));
+  CHECK_NAPI_RESULT(napi_create_function(env, "libsassVersion", -1, libsass_version, nullptr, &functionLibsassVersion));
 
   CHECK_NAPI_RESULT(napi_set_named_property(env, target, "render", functionRender));
   CHECK_NAPI_RESULT(napi_set_named_property(env, target, "renderSync", functionRenderSync));
@@ -486,6 +486,7 @@ void Init(napi_env env, napi_value target, napi_value module, void* priv) {
   CHECK_NAPI_RESULT(napi_set_named_property(env, target, "libsassVersion", functionLibsassVersion));
 
   SassTypes::Factory::initExports(env, target);
+  return target;
 }
 
 NAPI_MODULE(binding, Init)

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -469,15 +469,15 @@ napi_value libsass_version(napi_env env, napi_callback_info info) {
 
 napi_value Init(napi_env env, napi_value target) {
   napi_value functionRender;
-  CHECK_NAPI_RESULT(napi_create_function(env, "render", -1, render, nullptr, &functionRender));
+  CHECK_NAPI_RESULT(napi_create_function(env, "render", NAPI_AUTO_LENGTH, render, nullptr, &functionRender));
   napi_value functionRenderSync;
-  CHECK_NAPI_RESULT(napi_create_function(env, "renderSync", -1, render_sync, nullptr, &functionRenderSync));
+  CHECK_NAPI_RESULT(napi_create_function(env, "renderSync", NAPI_AUTO_LENGTH, render_sync, nullptr, &functionRenderSync));
   napi_value functionRenderFile;
-  CHECK_NAPI_RESULT(napi_create_function(env, "renderFile", -1, render_file, nullptr, &functionRenderFile));
+  CHECK_NAPI_RESULT(napi_create_function(env, "renderFile", NAPI_AUTO_LENGTH, render_file, nullptr, &functionRenderFile));
   napi_value functionRenderFileSync;
-  CHECK_NAPI_RESULT(napi_create_function(env, "renderFileSync", -1, render_file_sync, nullptr, &functionRenderFileSync));
+  CHECK_NAPI_RESULT(napi_create_function(env, "renderFileSync", NAPI_AUTO_LENGTH, render_file_sync, nullptr, &functionRenderFileSync));
   napi_value functionLibsassVersion;
-  CHECK_NAPI_RESULT(napi_create_function(env, "libsassVersion", -1, libsass_version, nullptr, &functionLibsassVersion));
+  CHECK_NAPI_RESULT(napi_create_function(env, "libsassVersion", NAPI_AUTO_LENGTH, libsass_version, nullptr, &functionLibsassVersion));
 
   CHECK_NAPI_RESULT(napi_set_named_property(env, target, "render", functionRender));
   CHECK_NAPI_RESULT(napi_set_named_property(env, target, "renderSync", functionRenderSync));

--- a/src/callback_bridge.h
+++ b/src/callback_bridge.h
@@ -134,7 +134,7 @@ T CallbackBridge<T, L>::operator()(std::vector<void*> argv) {
     CHECK_NAPI_RESULT(napi_is_exception_pending(this->e, &isPending));
 
     if (isPending) {
-      CHECK_NAPI_RESULT(napi_throw_error(this->e, "Error processing arguments"));
+      CHECK_NAPI_RESULT(napi_throw_error(this->e, nullptr, "Error processing arguments"));
       // This should be a FatalException but we still have to return something, this value might be uninitialized
       return this->return_value;
     }
@@ -199,7 +199,7 @@ void CallbackBridge<T, L>::dispatched_async_uv_callback(uv_async_t *req) {
 
   CHECK_NAPI_RESULT(napi_is_exception_pending(bridge->e, &isPending));
   if (isPending) {
-      CHECK_NAPI_RESULT(napi_throw_error(bridge->e, "Error processing arguments"));
+      CHECK_NAPI_RESULT(napi_throw_error(bridge->e, nullptr, "Error processing arguments"));
       // This should be a FatalException
       return;
   }
@@ -217,7 +217,7 @@ void CallbackBridge<T, L>::dispatched_async_uv_callback(uv_async_t *req) {
   CHECK_NAPI_RESULT(napi_make_callback(bridge->e, _this, cb, argv_v8.size(), &argv_v8[0], &result));
   CHECK_NAPI_RESULT(napi_is_exception_pending(bridge->e, &isPending));
   if (isPending) {
-      CHECK_NAPI_RESULT(napi_throw_error(bridge->e, "Error thrown in callback"));
+      CHECK_NAPI_RESULT(napi_throw_error(bridge->e, nullptr, "Error thrown in callback"));
       // This should be a FatalException
       return;
   }

--- a/src/callback_bridge.h
+++ b/src/callback_bridge.h
@@ -149,7 +149,7 @@ T CallbackBridge<T, L>::operator()(std::vector<void*> argv) {
 
     napi_value result;
     // TODO: Is receiver set correctly ?
-    CHECK_NAPI_RESULT(napi_make_callback(this->e, _this, cb, argv_v8.size(), &argv_v8[0], &result));
+    CHECK_NAPI_RESULT(napi_make_callback(this->e, nullptr, _this, cb, argv_v8.size(), &argv_v8[0], &result));
 
     return this->post_process_return_value(this->e, result);
   } else {
@@ -214,7 +214,7 @@ void CallbackBridge<T, L>::dispatched_async_uv_callback(uv_async_t *req) {
 
   napi_value result;
   // TODO: Is receiver set correctly ?
-  CHECK_NAPI_RESULT(napi_make_callback(bridge->e, _this, cb, argv_v8.size(), &argv_v8[0], &result));
+  CHECK_NAPI_RESULT(napi_make_callback(bridge->e, nullptr, _this, cb, argv_v8.size(), &argv_v8[0], &result));
   CHECK_NAPI_RESULT(napi_is_exception_pending(bridge->e, &isPending));
   if (isPending) {
       CHECK_NAPI_RESULT(napi_throw_error(bridge->e, nullptr, "Error thrown in callback"));
@@ -272,7 +272,7 @@ napi_ref CallbackBridge<T, L>::get_wrapper_constructor(napi_env env) {
   };
 
   napi_value ctor;
-  CHECK_NAPI_RESULT(napi_define_class(env, "CallbackBridge", CallbackBridge::New, nullptr, 1, methods, &ctor));
+  CHECK_NAPI_RESULT(napi_define_class(env, "CallbackBridge", -1, CallbackBridge::New, nullptr, 1, methods, &ctor));
   CHECK_NAPI_RESULT(napi_create_reference(env, ctor, 1, &wrapper_constructor));
 
   return wrapper_constructor;

--- a/src/callback_bridge.h
+++ b/src/callback_bridge.h
@@ -272,7 +272,7 @@ napi_ref CallbackBridge<T, L>::get_wrapper_constructor(napi_env env) {
   };
 
   napi_value ctor;
-  CHECK_NAPI_RESULT(napi_define_class(env, "CallbackBridge", -1, CallbackBridge::New, nullptr, 1, methods, &ctor));
+  CHECK_NAPI_RESULT(napi_define_class(env, "CallbackBridge", NAPI_AUTO_LENGTH, CallbackBridge::New, nullptr, 1, methods, &ctor));
   CHECK_NAPI_RESULT(napi_create_reference(env, ctor, 1, &wrapper_constructor));
 
   return wrapper_constructor;

--- a/src/common.h
+++ b/src/common.h
@@ -1,6 +1,8 @@
 ﻿#ifndef COMMON_H
 #define COMMON_H
 
+#include <cassert>
+
 #define CHECK_NAPI_RESULT(condition) \
   do { napi_status status = (condition); assert(status == napi_ok || status == napi_pending_exception); } while(0)
 

--- a/src/sass_types/boolean.cpp
+++ b/src/sass_types/boolean.cpp
@@ -68,7 +68,7 @@ namespace SassTypes
 
     if (r) {
       if (constructor_locked) {
-        CHECK_NAPI_RESULT(napi_throw_type_error(env, "Cannot instantiate SassBoolean"));
+        CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Cannot instantiate SassBoolean"));
         return nullptr;
       }
     } else {
@@ -77,7 +77,7 @@ namespace SassTypes
       CHECK_NAPI_RESULT(napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr));
 
       if (argc != 1) {
-        CHECK_NAPI_RESULT(napi_throw_type_error(env, "Expected one boolean argument"));
+        CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Expected one boolean argument"));
         return nullptr;
       }
 
@@ -85,7 +85,7 @@ namespace SassTypes
       CHECK_NAPI_RESULT(napi_typeof(env, argv[0], &t));
 
       if (t != napi_boolean) {
-        CHECK_NAPI_RESULT(napi_throw_type_error(env, "Expected one boolean argument"));
+        CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Expected one boolean argument"));
         return nullptr;
       }
 

--- a/src/sass_types/boolean.cpp
+++ b/src/sass_types/boolean.cpp
@@ -34,7 +34,7 @@ namespace SassTypes
         { "getValue", nullptr, Boolean::GetValue },
       };
 
-      CHECK_NAPI_RESULT(napi_define_class(env, "SassBoolean", Boolean::New, nullptr, 1, methods, &ctor));
+      CHECK_NAPI_RESULT(napi_define_class(env, "SassBoolean", -1, Boolean::New, nullptr, 1, methods, &ctor));
       CHECK_NAPI_RESULT(napi_create_reference(env, ctor, 1, &Boolean::constructor));
 
       Boolean& falseSingleton = get_singleton(false);
@@ -63,8 +63,9 @@ namespace SassTypes
   }
 
   napi_value Boolean::New(napi_env env, napi_callback_info info) {
-    bool r;
-    CHECK_NAPI_RESULT(napi_is_construct_call(env, info, &r));
+    napi_value t;
+    CHECK_NAPI_RESULT(napi_get_new_target(env, info, &t));
+    bool r = (t != nullptr);
 
     if (r) {
       if (constructor_locked) {

--- a/src/sass_types/boolean.cpp
+++ b/src/sass_types/boolean.cpp
@@ -34,7 +34,7 @@ namespace SassTypes
         { "getValue", nullptr, Boolean::GetValue },
       };
 
-      CHECK_NAPI_RESULT(napi_define_class(env, "SassBoolean", -1, Boolean::New, nullptr, 1, methods, &ctor));
+      CHECK_NAPI_RESULT(napi_define_class(env, "SassBoolean", NAPI_AUTO_LENGTH, Boolean::New, nullptr, 1, methods, &ctor));
       CHECK_NAPI_RESULT(napi_create_reference(env, ctor, 1, &Boolean::constructor));
 
       Boolean& falseSingleton = get_singleton(false);

--- a/src/sass_types/color.cpp
+++ b/src/sass_types/color.cpp
@@ -73,7 +73,7 @@ namespace SassTypes
       { "setA", nullptr, SetA },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 8, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), NAPI_AUTO_LENGTH, cb, nullptr, 8, descriptors, &ctor));
     return ctor;
   }
 

--- a/src/sass_types/color.cpp
+++ b/src/sass_types/color.cpp
@@ -73,7 +73,7 @@ namespace SassTypes
       { "setA", nullptr, SetA },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), cb, nullptr, 8, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 8, descriptors, &ctor));
     return ctor;
   }
 

--- a/src/sass_types/error.cpp
+++ b/src/sass_types/error.cpp
@@ -24,7 +24,7 @@ namespace SassTypes
 
   napi_value Error::getConstructor(napi_env env, napi_callback cb) {
     napi_value ctor;
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 0, nullptr, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), NAPI_AUTO_LENGTH, cb, nullptr, 0, nullptr, &ctor));
     return ctor;
   }
 }

--- a/src/sass_types/error.cpp
+++ b/src/sass_types/error.cpp
@@ -24,7 +24,7 @@ namespace SassTypes
 
   napi_value Error::getConstructor(napi_env env, napi_callback cb) {
     napi_value ctor;
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), cb, nullptr, 0, nullptr, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 0, nullptr, &ctor));
     return ctor;
   }
 }

--- a/src/sass_types/factory.cpp
+++ b/src/sass_types/factory.cpp
@@ -40,7 +40,7 @@ namespace SassTypes
 
     default:
       const char *msg = "Unknown type encountered.";
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, msg));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, msg));
       return new Error(env, sass_make_error(msg));
     }
   }

--- a/src/sass_types/list.cpp
+++ b/src/sass_types/list.cpp
@@ -43,7 +43,7 @@ namespace SassTypes
       { "setValue", nullptr, SetValue },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), cb, nullptr, 5, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 5, descriptors, &ctor));
     return ctor;
   }
 

--- a/src/sass_types/list.cpp
+++ b/src/sass_types/list.cpp
@@ -97,7 +97,7 @@ namespace SassTypes
 
     size_t s = sass_list_get_length(unwrap(env, _this)->value);
     napi_value ret;
-    CHECK_NAPI_RESULT(napi_create_number(env, (double)s, &ret));
+    CHECK_NAPI_RESULT(napi_create_double(env, (double)s, &ret));
     return ret;
   }
 }

--- a/src/sass_types/list.cpp
+++ b/src/sass_types/list.cpp
@@ -43,7 +43,7 @@ namespace SassTypes
       { "setValue", nullptr, SetValue },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 5, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), NAPI_AUTO_LENGTH, cb, nullptr, 5, descriptors, &ctor));
     return ctor;
   }
 

--- a/src/sass_types/list.cpp
+++ b/src/sass_types/list.cpp
@@ -72,7 +72,7 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_get_cb_info(env, info, &argc, &arg, &_this, nullptr));
 
     if (argc != 1) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Expected just one argument"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Expected just one argument"));
       return nullptr;
     }
 
@@ -80,7 +80,7 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_typeof(env, arg, &t));
 
     if (t != napi_boolean) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Supplied value should be a boolean"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Supplied value should be a boolean"));
       return nullptr;
     }
 

--- a/src/sass_types/map.cpp
+++ b/src/sass_types/map.cpp
@@ -31,7 +31,7 @@ namespace SassTypes
       { "setValue", nullptr, SetValue },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), cb, nullptr, 5, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 5, descriptors, &ctor));
     return ctor;
   }
 

--- a/src/sass_types/map.cpp
+++ b/src/sass_types/map.cpp
@@ -31,7 +31,7 @@ namespace SassTypes
       { "setValue", nullptr, SetValue },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 5, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), NAPI_AUTO_LENGTH, cb, nullptr, 5, descriptors, &ctor));
     return ctor;
   }
 

--- a/src/sass_types/map.cpp
+++ b/src/sass_types/map.cpp
@@ -57,7 +57,7 @@ namespace SassTypes
 
     size_t s = sass_map_get_length(unwrap(env, _this)->value);
     napi_value ret;
-    CHECK_NAPI_RESULT(napi_create_number(env, (double)s, &ret));
+    CHECK_NAPI_RESULT(napi_create_double(env, (double)s, &ret));
     return ret;
   }
 }

--- a/src/sass_types/null.cpp
+++ b/src/sass_types/null.cpp
@@ -60,7 +60,7 @@ namespace SassTypes
 
     if (r) {
       if (constructor_locked) {
-        CHECK_NAPI_RESULT(napi_throw_type_error(env, "Cannot instantiate SassNull"));
+        CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Cannot instantiate SassNull"));
       }
     }
     else {

--- a/src/sass_types/null.cpp
+++ b/src/sass_types/null.cpp
@@ -30,7 +30,7 @@ namespace SassTypes
     if (Null::constructor) {
       CHECK_NAPI_RESULT(napi_get_reference_value(env, Null::constructor, &ctor));
     } else {
-      CHECK_NAPI_RESULT(napi_define_class(env, "SassNull", -1, Null::New, nullptr, 0, nullptr, &ctor));
+      CHECK_NAPI_RESULT(napi_define_class(env, "SassNull", NAPI_AUTO_LENGTH, Null::New, nullptr, 0, nullptr, &ctor));
       CHECK_NAPI_RESULT(napi_create_reference(env, ctor, 1, &Null::constructor));
 
       Null& singleton = get_singleton();

--- a/src/sass_types/null.cpp
+++ b/src/sass_types/null.cpp
@@ -30,7 +30,7 @@ namespace SassTypes
     if (Null::constructor) {
       CHECK_NAPI_RESULT(napi_get_reference_value(env, Null::constructor, &ctor));
     } else {
-      CHECK_NAPI_RESULT(napi_define_class(env, "SassNull", Null::New, nullptr, 0, nullptr, &ctor));
+      CHECK_NAPI_RESULT(napi_define_class(env, "SassNull", -1, Null::New, nullptr, 0, nullptr, &ctor));
       CHECK_NAPI_RESULT(napi_create_reference(env, ctor, 1, &Null::constructor));
 
       Null& singleton = get_singleton();
@@ -55,8 +55,9 @@ namespace SassTypes
   }
 
   napi_value Null::New(napi_env env, napi_callback_info info) {
-    bool r;
-    CHECK_NAPI_RESULT(napi_is_construct_call(env, info, &r));
+    napi_value t;
+    CHECK_NAPI_RESULT(napi_get_new_target(env, info, &t));
+    bool r = (t != nullptr);
 
     if (r) {
       if (constructor_locked) {

--- a/src/sass_types/number.cpp
+++ b/src/sass_types/number.cpp
@@ -42,7 +42,7 @@ namespace SassTypes
         { "setUnit", nullptr, SetUnit },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 4, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), NAPI_AUTO_LENGTH, cb, nullptr, 4, descriptors, &ctor));
     return ctor;
   }
 

--- a/src/sass_types/number.cpp
+++ b/src/sass_types/number.cpp
@@ -42,7 +42,7 @@ namespace SassTypes
         { "setUnit", nullptr, SetUnit },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), cb, nullptr, 4, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 4, descriptors, &ctor));
     return ctor;
   }
 

--- a/src/sass_types/sass_value_wrapper.h
+++ b/src/sass_types/sass_value_wrapper.h
@@ -70,7 +70,7 @@ namespace SassTypes
     double d = fnc(unwrap(env, _this)->value);
 
     napi_value ret;
-    CHECK_NAPI_RESULT(napi_create_number(env, d, &ret));
+    CHECK_NAPI_RESULT(napi_create_double(env, d, &ret));
     return ret;
   }
 

--- a/src/sass_types/sass_value_wrapper.h
+++ b/src/sass_types/sass_value_wrapper.h
@@ -261,8 +261,9 @@ namespace SassTypes
     std::vector<napi_value> argv(argc);
     CHECK_NAPI_RESULT(napi_get_cb_info(env, info, &argc, argv.data(), nullptr, nullptr));
 
-    bool r;
-    CHECK_NAPI_RESULT(napi_is_construct_call(env, info, &r));
+    napi_value t;
+    CHECK_NAPI_RESULT(napi_get_new_target(env, info, &t));
+    bool r = (t != nullptr);
 
     if (r) {
       Sass_Value* value;

--- a/src/sass_types/sass_value_wrapper.h
+++ b/src/sass_types/sass_value_wrapper.h
@@ -82,7 +82,7 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_get_cb_info(env, info, &argc, &arg, &_this, nullptr));
 
     if (argc != 1) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Expected just one argument"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Expected just one argument"));
       return nullptr;
     }
 
@@ -90,7 +90,7 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_typeof(env, arg, &t));
 
     if (t != napi_number) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Supplied value should be a number"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Supplied value should be a number"));
       return nullptr;
     }
 
@@ -122,7 +122,7 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_get_cb_info(env, info, &argc, &arg, &_this, nullptr));
 
     if (argc != 1) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Expected just one argument"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Expected just one argument"));
       return nullptr;
     }
 
@@ -130,7 +130,7 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_typeof(env, arg, &t));
 
     if (t != napi_string) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Supplied value should be a string"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Supplied value should be a string"));
       return nullptr;
     }
 
@@ -148,7 +148,7 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_get_cb_info(env, info, &argc, &arg, &_this, nullptr));
 
     if (argc != 1) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Expected just one argument"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Expected just one argument"));
       return nullptr;
     }
 
@@ -156,7 +156,7 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_typeof(env, arg, &t));
 
     if (t != napi_number) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Supplied index should be an integer"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Supplied index should be an integer"));
       return nullptr;
     }
 
@@ -166,7 +166,7 @@ namespace SassTypes
     Sass_Value* collection = unwrap(env, _this)->value;
 
     if (index >= lenfnc(collection)) {
-      CHECK_NAPI_RESULT(napi_throw_range_error(env, "Out of bound index"));
+      CHECK_NAPI_RESULT(napi_throw_range_error(env, nullptr, "Out of bound index"));
       return nullptr;
     }
 
@@ -182,7 +182,7 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_get_cb_info(env, info, &argc, argv, &_this, nullptr));
 
     if (argc != 2) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Expected two arguments"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Expected two arguments"));
       return nullptr;
     }
 
@@ -190,14 +190,14 @@ namespace SassTypes
     CHECK_NAPI_RESULT(napi_typeof(env, argv[0], &t));
 
     if (t != napi_number) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Supplied index should be an integer"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Supplied index should be an integer"));
       return nullptr;
     }
 
     CHECK_NAPI_RESULT(napi_typeof(env, argv[1], &t));
 
     if (t != napi_object) {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "Supplied value should be a SassValue object"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "Supplied value should be a SassValue object"));
       return nullptr;
     }
 
@@ -209,7 +209,7 @@ namespace SassTypes
         setfnc(unwrap(env, _this)->value, v, sass_value->get_sass_value());
     }
     else {
-      CHECK_NAPI_RESULT(napi_throw_type_error(env, "A SassValue is expected"));
+      CHECK_NAPI_RESULT(napi_throw_type_error(env, nullptr, "A SassValue is expected"));
     }
     return nullptr;
   }
@@ -274,7 +274,7 @@ namespace SassTypes
         CHECK_NAPI_RESULT(napi_create_reference(env, _this, 1, &obj->js_object));
         return _this;
       } else {
-        CHECK_NAPI_RESULT(napi_throw_error(env, sass_error_get_message(value)));
+        CHECK_NAPI_RESULT(napi_throw_error(env, nullptr, sass_error_get_message(value)));
       }
     } else {
       napi_value ctor = T::get_constructor(env);

--- a/src/sass_types/sass_value_wrapper.h
+++ b/src/sass_types/sass_value_wrapper.h
@@ -226,7 +226,7 @@ namespace SassTypes
       napi_value ctor = T::get_constructor(env);
       CHECK_NAPI_RESULT(napi_new_instance(env, ctor, 0, nullptr, &wrapper));
       void* wrapped;
-      CHECK_NAPI_RESULT(napi_unwrap(env, wrapper, &wrapped));
+      CHECK_NAPI_RESULT(napi_remove_wrap(env, wrapper, &wrapped));
       delete static_cast<T*>(wrapped);
       CHECK_NAPI_RESULT(napi_wrap(env, wrapper, this, nullptr, nullptr, nullptr));
       CHECK_NAPI_RESULT(napi_create_reference(env, wrapper, 1, &this->js_object));

--- a/src/sass_types/string.cpp
+++ b/src/sass_types/string.cpp
@@ -29,7 +29,7 @@ namespace SassTypes
       { "setValue", nullptr, SetValue },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), cb, nullptr, 2, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 2, descriptors, &ctor));
     return ctor;
   }
 

--- a/src/sass_types/string.cpp
+++ b/src/sass_types/string.cpp
@@ -29,7 +29,7 @@ namespace SassTypes
       { "setValue", nullptr, SetValue },
     };
 
-    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), -1, cb, nullptr, 2, descriptors, &ctor));
+    CHECK_NAPI_RESULT(napi_define_class(env, get_constructor_name(), NAPI_AUTO_LENGTH, cb, nullptr, 2, descriptors, &ctor));
     return ctor;
   }
 


### PR DESCRIPTION
1. currently node-sass does not support node version higher than 8, so I add the case for node 9 to make it able to run with node master

2. at the end of running `npm install`, the prepublish script gets invoked as well, and the `not-in-install` and `in-install` condition isn't stopping it. so I change the condition to `in-publish` and `not-in-publish`. Since npm complain `prepublish` is deprecated, so I also change it to `prepare`.